### PR TITLE
chore: remove custom commitlint configuration

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Deletes the custom commitlint configuration file to simplify the 
commit process by relying on the default settings provided by 
@commitlint/config-conventional. This change aims to enhance 
consistency across commits and streamline configuration management.